### PR TITLE
Fixes kerberos-io/machinery#101

### DIFF
--- a/src/kerberos/cloud/Cloud.cpp
+++ b/src/kerberos/cloud/Cloud.cpp
@@ -291,7 +291,6 @@ namespace kerberos
     {
         cloudConnection = new RestClient::Connection(CLOUD);
         pthread_create(&m_healthThread, NULL, deviceHealth, this);
-        pthread_detach(m_healthThread);
     }
 
     void Cloud::stopHealthThread()


### PR DESCRIPTION
Hi @cedricve


healthThread for Cloud service is being [detached](https://github.com/kerberos-io/machinery/blob/98ede32982a37a8045717b169fcfc7f85221ecb8/src/kerberos/cloud/Cloud.cpp#L294) .

But then in stopHealthThread the thread is [joined](https://github.com/kerberos-io/machinery/blob/98ede32982a37a8045717b169fcfc7f85221ecb8/src/kerberos/cloud/Cloud.cpp#L301).

[stopHealthThread](https://github.com/kerberos-io/machinery/blob/98ede32982a37a8045717b169fcfc7f85221ecb8/src/kerberos/Kerberos.cpp#L253) is called in Kerberos.cpp.

pthread documentation states that the behaviour is unexpected when joining a detached thread.

In fact, before the fix, i could often reproduce the issue (not always but often). 
Debugging showed that the IOThread was exiting (verified with ps command on linux that the thread exited) and that was occurring around when stopHealthCheck for Cloud was being called.

Of course with threads you never know, but the issue has not resurfaced after applying the fix.

Any special reason why you had detached that thread? 