### PR TITLE
Check capture directory specifically rather than fixed device

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,7 +4,7 @@ autoremoval() {
     while true; do
         sleep 60
 
-        if [[ $(df -h | grep /dev/vda1 | head -1 | awk -F' ' '{ print $5/1 }' | tr ['%'] ["0"]) -gt 90 ]];
+        if [[ $(df -h /etc/opt/kerberosio/capture | tail -1 | awk -F' ' '{ print $5/1 }' | tr ['%'] ["0"]) -gt 90 ]];
         then
                 echo "Cleaning disk"
                 find /etc/opt/kerberosio/capture/ -type f | sort | head -n 100 | xargs rm;


### PR DESCRIPTION
Refs Issue #116 

This checks the device behind the capture directory and retrieves the specific info, rather than /dev/vda1 which doesn't exist on my system at least