### PR TITLE
remove ampersand from service unit

### DIFF
--- a/service/kerberosio.service
+++ b/service/kerberosio.service
@@ -3,7 +3,7 @@ Description=Kerberos.io - Machinery - video surveillance
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/kerberosio &
+ExecStart=/usr/bin/kerberosio
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3


### PR DESCRIPTION
systemd isn't bash. The ampersand isn't required to put it into the background.